### PR TITLE
fix null pointer derefs when an error occurs

### DIFF
--- a/src/magic_nums.cpp
+++ b/src/magic_nums.cpp
@@ -234,7 +234,7 @@ int lua_MagicNumbersSetValue(lua_State* L)
         auto value = luaL_checklstring(L, 2, &length);
         *(vs13::string*)magic_num.address = vs13::string{value, length};
     } else {
-        luaL_error(
+        return luaL_error(
             L,
             "Magic number '%s' has unsupported data type '%s' for assignment",
             name,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -547,7 +547,7 @@ int SetActiveHeldEntity(lua_State* L)
     auto entity = entity_get_by_id(entity_manager, entity_id);
     auto item = entity_get_by_id(entity_manager, item_id);
     if (!entity)
-        luaL_error(L, "Entity %d not found.", entity_id);
+        return luaL_error(L, "Entity %d not found.", entity_id);
 
     set_active_held_entity(entity, item, unknown, make_noise);
     #ifdef __GNUC__
@@ -808,12 +808,12 @@ int SetPauseState(lua_State* L)
     int value = luaL_checkinteger(L, 1);
 
     if (!get_game_global)
-        luaL_error(L, "Couldn't find function for retrieving game global");
+        return luaL_error(L, "Couldn't find function for retrieving game global");
 
     auto GG = get_game_global();
 
     if (!GG->pause_state)
-        luaL_error(L, "Game global is missing pause state");
+        return luaL_error(L, "Game global is missing pause state");
 
     lua_pushinteger(L, *GG->pause_state);
     *GG->pause_state = value;
@@ -824,12 +824,12 @@ int SetPauseState(lua_State* L)
 int GetPauseState(lua_State* L)
 {
     if (!get_game_global)
-        luaL_error(L, "Couldn't find function for retrieving game global");
+        return luaL_error(L, "Couldn't find function for retrieving game global");
 
     auto GG = get_game_global();
 
     if (!GG->pause_state)
-        luaL_error(L, "Game global is missing pause state");
+        return luaL_error(L, "Game global is missing pause state");
 
     lua_pushinteger(L, *GG->pause_state);
     return 1;

--- a/src/noita_ui.cpp
+++ b/src/noita_ui.cpp
@@ -104,7 +104,7 @@ int SetInventoryCursorEnabled(lua_State* L)
     bool enable = lua_toboolean(L, 1);
     auto grid_hook = get_grid_hook();
     if (!grid_hook) {
-        luaL_error(L, "Couldn't hook ui grid container function");
+        return luaL_error(L, "Couldn't hook ui grid container function");
     }
 
     // Enabling hook means disabling cursor

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -16,7 +16,7 @@ int PhysBodySetTransform(lua_State* L)
 
     auto component = ComponentById(component_id);
     if (!component) {
-        luaL_error(L, "Component not found.");
+        return luaL_error(L, "Component not found.");
     }
 
     auto b2body = *(char**)((char*)component + 0x48);
@@ -37,7 +37,7 @@ int PhysBodyGetTransform(lua_State* L)
 
     auto component = ComponentById(component_id);
     if (!component) {
-        luaL_error(L, "Component not found.");
+        return luaL_error(L, "Component not found.");
     }
 
     auto b2body = *(char**)((char*)component + 0x48);


### PR DESCRIPTION
I can't get the build actions working so can't test, but i think this looks sane. Currently if noitapatcher raises a lua error in many places it just crashes immediately so you can't see the error.